### PR TITLE
Initial persistent dialog implementation

### DIFF
--- a/src/ndb/ndb.cc
+++ b/src/ndb/ndb.cc
@@ -414,12 +414,12 @@ void NDB::allowPersistentDialog() {
  */
 void NDB::dlgConfirmPersistentShow(QString const& title, QString const& body) {
     NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, allowPersistentDlg, "dialog already showing");
-    allowPersistentDlg = false;
     NDB_DBUS_USB_ASSERT((void) 0);
     NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialogFactory_getConfirmationDialog && nSym.ConfirmationDialog__setTitle &&
         nSym.ConfirmationDialog__setText && nSym.ConfirmationDialog__showCloseButton && nSym.ConfirmationDialog__setRejectOnOutsideTap);
     persistentDlg = nSym.ConfirmationDialogFactory_getConfirmationDialog(nullptr);
     NDB_DBUS_ASSERT((void) 0, QDBusError::InternalError, persistentDlg, "error getting confirmation dialog");
+    allowPersistentDlg = false;
     nSym.ConfirmationDialog__setTitle(persistentDlg, title);
     nSym.ConfirmationDialog__setText(persistentDlg, body);
     // This makes the dialog a true modal, where you cannot tap outside it to dismiss
@@ -457,12 +457,12 @@ void NDB::dlgConfirmPersistentClose() {
 
 void NDB::dlgConfirmation(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText) {
     NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, allowDlg, "dialog already showing");
-    allowDlg = false;
     NDB_DBUS_USB_ASSERT((void) 0);
     NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialogFactory_getConfirmationDialog && nSym.ConfirmationDialog__setTitle &&
         nSym.ConfirmationDialog__setText && nSym.ConfirmationDialog__setAcceptButtonText && nSym.ConfirmationDialog__setRejectButtonText);
     ConfirmationDialog *dlg = nSym.ConfirmationDialogFactory_getConfirmationDialog(nullptr);
     NDB_DBUS_ASSERT((void) 0, QDBusError::InternalError, dlg, "error getting confirmation dialog");
+    allowDlg = false;
     
     nSym.ConfirmationDialog__setTitle(dlg, title);
     nSym.ConfirmationDialog__setText(dlg, body);

--- a/src/ndb/ndb.cc
+++ b/src/ndb/ndb.cc
@@ -404,11 +404,11 @@ void NDB::allowDialog() {
  * \brief Show dialog without buttons that can be programatically dismissed
  * 
  * Create a dialog box with \a title and \a body. This dialog has no close
- * button, and is expected to be closed by \l dlgConfirmClosePersistent
+ * button, and is expected to be closed by \l dlgConfirmPersistentClose
  * 
  * When the dialog is closed, a \l dlgConfirmResult() signal is emitted.
  */
-void NDB::dlgConfirmShowPersistent(QString const& title, QString const& body) {
+void NDB::dlgConfirmPersistentShow(QString const& title, QString const& body) {
     NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, allowDlg, "dialog already showing");
     allowDlg = false;
     NDB_DBUS_USB_ASSERT((void) 0);
@@ -427,12 +427,24 @@ void NDB::dlgConfirmShowPersistent(QString const& title, QString const& body) {
 }
 
 /*!
- * \brief Close dialog created by \l dlgConfirmShowPersistent
+ * \brief Change body text of currently displayed persistent dialog
  * 
- * Closes the dialog created by \l dlgConfirmShowPersistent. Will return an
+ * Set the body text of the currently displayed persistent dialog to \a body
+ * replacing the existing body text.
+ */ 
+void NDB::dlgConfirmPersistentChange(QString const& body) {
+    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowDlg, "dialog not showing");
+    NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialog__setText);
+    nSym.ConfirmationDialog__setText(persistentDlg, body);
+}
+
+/*!
+ * \brief Close dialog created by \l dlgConfirmPersistentShow
+ * 
+ * Closes the dialog created by \l dlgConfirmPersistentShow. Will return an
  * error if the dialog has already been closed by the user.
  */
-void NDB::dlgConfirmClosePersistent() {
+void NDB::dlgConfirmPersistentClose() {
     NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowDlg, "dialog not showing");
     persistentDlg->accept();
 }

--- a/src/ndb/ndb.cc
+++ b/src/ndb/ndb.cc
@@ -50,7 +50,7 @@ NDB::NDB(QObject* parent) : QObject(parent), QDBusContext() {
         initSucceeded = false;
         return;
     }
-    persistentDlg = nullptr;
+    confirmDlg = nullptr;
     // The following symbols are required. If they can't be resolved, bail out
     ndbResolveSymbol("_ZN11PlugManager14sharedInstanceEv", nh_symoutptr(nSym.PlugManager__sharedInstance));
     ndbResolveSymbol("_ZNK11PlugManager10gadgetModeEv", nh_symoutptr(nSym.PlugManager__gadgetMode));
@@ -400,81 +400,32 @@ void NDB::allowDialog() {
     allowDlg = true;
 }
 
-void NDB::allowPersistentDialog() {
-    allowPersistentDlg = true;
-}
-
-/*!
- * \brief Show dialog without buttons that can be programatically dismissed
- * 
- * Create a dialog box with \a title and \a body. This dialog has no close
- * button, and is expected to be closed by \l dlgConfirmPersistentClose
- * 
- * When the dialog is closed, a \l dlgConfirmResult() signal is emitted.
- */
-void NDB::dlgConfirmPersistentShow(QString const& title, QString const& body) {
-    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, allowPersistentDlg, "dialog already showing");
-    NDB_DBUS_USB_ASSERT((void) 0);
-    NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialogFactory_getConfirmationDialog && nSym.ConfirmationDialog__setTitle &&
-        nSym.ConfirmationDialog__setText && nSym.ConfirmationDialog__showCloseButton && nSym.ConfirmationDialog__setRejectOnOutsideTap);
-    persistentDlg = nSym.ConfirmationDialogFactory_getConfirmationDialog(nullptr);
-    NDB_DBUS_ASSERT((void) 0, QDBusError::InternalError, persistentDlg, "error getting confirmation dialog");
-    allowPersistentDlg = false;
-    nSym.ConfirmationDialog__setTitle(persistentDlg, title);
-    nSym.ConfirmationDialog__setText(persistentDlg, body);
-    // This makes the dialog a true modal, where you cannot tap outside it to dismiss
-    nSym.ConfirmationDialog__setRejectOnOutsideTap(persistentDlg, false);
-    persistentDlg->setModal(true);
-    QObject::connect(persistentDlg, &QDialog::finished, this, &NDB::allowPersistentDialog);
-    QObject::connect(persistentDlg, &QDialog::finished, persistentDlg, &QDialog::deleteLater);
-    persistentDlg->open();
-}
-
-/*!
- * \brief Change body text of currently displayed persistent dialog
- * 
- * Set the body text of the currently displayed persistent dialog to \a body
- * replacing the existing body text.
- * 
- * There will be an error if the user has closed the dialog.
- */ 
-void NDB::dlgConfirmPersistentChange(QString const& body) {
-    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowPersistentDlg, "dialog not showing");
-    NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialog__setText);
-    nSym.ConfirmationDialog__setText(persistentDlg, body);
-}
-
-/*!
- * \brief Close dialog created by \l dlgConfirmPersistentShow
- * 
- * Closes the dialog created by \l dlgConfirmPersistentShow. Will return an
- * error if the dialog has already been closed by the user.
- */
-void NDB::dlgConfirmPersistentClose() {
-    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowPersistentDlg, "dialog not showing");
-    persistentDlg->accept();
-}
-
-void NDB::dlgConfirmation(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText) {
+void NDB::dlgConfirmation(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText, bool tapOutsideClose, bool sendSignal) {
     NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, allowDlg, "dialog already showing");
     NDB_DBUS_USB_ASSERT((void) 0);
-    NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialogFactory_getConfirmationDialog && nSym.ConfirmationDialog__setTitle &&
-        nSym.ConfirmationDialog__setText && nSym.ConfirmationDialog__setAcceptButtonText && nSym.ConfirmationDialog__setRejectButtonText);
-    ConfirmationDialog *dlg = nSym.ConfirmationDialogFactory_getConfirmationDialog(nullptr);
-    NDB_DBUS_ASSERT((void) 0, QDBusError::InternalError, dlg, "error getting confirmation dialog");
+    NDB_DBUS_SYM_ASSERT((void) 0, 
+        nSym.ConfirmationDialogFactory_getConfirmationDialog && 
+        nSym.ConfirmationDialog__setTitle &&
+        nSym.ConfirmationDialog__setText && 
+        nSym.ConfirmationDialog__setAcceptButtonText && 
+        nSym.ConfirmationDialog__setRejectButtonText && 
+        nSym.ConfirmationDialog__setRejectOnOutsideTap);
+    confirmDlg = nSym.ConfirmationDialogFactory_getConfirmationDialog(nullptr);
+    NDB_DBUS_ASSERT((void) 0, QDBusError::InternalError, confirmDlg, "error getting confirmation dialog");
     allowDlg = false;
     
-    nSym.ConfirmationDialog__setTitle(dlg, title);
-    nSym.ConfirmationDialog__setText(dlg, body);
+    nSym.ConfirmationDialog__setTitle(confirmDlg, title);
+    nSym.ConfirmationDialog__setText(confirmDlg, body);
+    nSym.ConfirmationDialog__setRejectOnOutsideTap(confirmDlg, tapOutsideClose);
 
-    if (!acceptText.isEmpty()) { nSym.ConfirmationDialog__setAcceptButtonText(dlg, acceptText); }
-    if (!rejectText.isEmpty()) { nSym.ConfirmationDialog__setRejectButtonText(dlg, rejectText); }
+    if (!acceptText.isEmpty()) { nSym.ConfirmationDialog__setAcceptButtonText(confirmDlg, acceptText); }
+    if (!rejectText.isEmpty()) { nSym.ConfirmationDialog__setRejectButtonText(confirmDlg, rejectText); }
 
-    dlg->setModal(true);
-    QObject::connect(dlg, &QDialog::finished, this, &NDB::dlgConfirmResult);
-    QObject::connect(dlg, &QDialog::finished, this, &NDB::allowDialog);
-    QObject::connect(dlg, &QDialog::finished, dlg, &QDialog::deleteLater);
-    dlg->open();
+    confirmDlg->setModal(true);
+    if (sendSignal) { QObject::connect(confirmDlg, &QDialog::finished, this, &NDB::dlgConfirmResult); }
+    QObject::connect(confirmDlg, &QDialog::finished, this, &NDB::allowDialog);
+    QObject::connect(confirmDlg, &QDialog::finished, confirmDlg, &QDialog::deleteLater);
+    confirmDlg->open();
 }
 
 /*!
@@ -486,7 +437,7 @@ void NDB::dlgConfirmation(QString const& title, QString const& body, QString con
  * When the dialog is closed, a \l dlgConfirmResult() signal is emitted.
  */
 void NDB::dlgConfirmNoBtn(QString const& title, QString const& body) {
-    return dlgConfirmation(title, body, QString(""), QString(""));
+    return dlgConfirmation(title, body, QString(""), QString(""), true, true);
 }
 
 /*!
@@ -499,7 +450,7 @@ void NDB::dlgConfirmNoBtn(QString const& title, QString const& body) {
  * \l dlgConfirmResult() signal is emitted.
  */
 void NDB::dlgConfirmAccept(QString const& title, QString const& body, QString const& acceptText) {
-    return dlgConfirmation(title, body, acceptText, QString(""));
+    return dlgConfirmation(title, body, acceptText, QString(""), true, true);
 }
 
 /*!
@@ -512,7 +463,7 @@ void NDB::dlgConfirmAccept(QString const& title, QString const& body, QString co
  * \l dlgConfirmResult() signal is emitted.
  */
 void NDB::dlgConfirmReject(QString const& title, QString const& body, QString const& rejectText) {
-    return dlgConfirmation(title, body, QString(""), rejectText);
+    return dlgConfirmation(title, body, QString(""), rejectText, true, true);
 }
 
 /*!
@@ -526,7 +477,50 @@ void NDB::dlgConfirmReject(QString const& title, QString const& body, QString co
  * \l dlgConfirmResult() signal is emitted.
  */
 void NDB::dlgConfirmAcceptReject(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText) {
-    return dlgConfirmation(title, body, acceptText, rejectText);
+    return dlgConfirmation(title, body, acceptText, rejectText, true, true);
+}
+
+/*!
+ * \brief Show confirmation dialog without buttons that can only be closed with close button, or programatically
+ * 
+ * Create a dialog box with \a title and \a body. This dialog has a close
+ * button for safety, but is expected to be closed by \l dlgConfirmClose
+ * 
+ * No signal is emitted when the dialog is closed
+ * 
+ * \since 0.2.0
+ */
+void NDB::dlgConfirmModalMessage(QString const& title, QString const& body) {
+    return dlgConfirmation(title, body, QString(""), QString(""), false, false);
+}
+
+/*!
+ * \brief Change body text of currently displayed dialog
+ * 
+ * Set the body text of the currently displayed dialog to \a body
+ * replacing the existing body text.
+ * 
+ * There will be an error if the user has closed the dialog.
+ * 
+ * \since 0.2.0
+ */ 
+void NDB::dlgConfirmChangeBody(QString const& body) {
+    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowDlg, "dialog not showing");
+    NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialog__setText);
+    nSym.ConfirmationDialog__setText(confirmDlg, body);
+}
+
+/*!
+ * \brief Close the currently opened dialog
+ * 
+ * Closes the currently open dialog. Will return an
+ * error if the dialog has already been closed by the user.
+ * 
+ * \since 0.2.0
+ */
+void NDB::dlgConfirmClose() {
+    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowDlg, "dialog not showing");
+    confirmDlg->accept();
 }
 
 /*!

--- a/src/ndb/ndb.cc
+++ b/src/ndb/ndb.cc
@@ -434,7 +434,7 @@ void NDB::dlgConfirmShowPersistent(QString const& title, QString const& body) {
  */
 void NDB::dlgConfirmClosePersistent() {
     NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowDlg, "dialog not showing");
-    persistentDlg->done(QDialog::Accepted);
+    persistentDlg->accept();
 }
 
 void NDB::dlgConfirmation(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText) {

--- a/src/ndb/ndb.cc
+++ b/src/ndb/ndb.cc
@@ -400,6 +400,10 @@ void NDB::allowDialog() {
     allowDlg = true;
 }
 
+void NDB::allowPersistentDialog() {
+    allowPersistentDlg = true;
+}
+
 /*!
  * \brief Show dialog without buttons that can be programatically dismissed
  * 
@@ -409,8 +413,8 @@ void NDB::allowDialog() {
  * When the dialog is closed, a \l dlgConfirmResult() signal is emitted.
  */
 void NDB::dlgConfirmPersistentShow(QString const& title, QString const& body) {
-    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, allowDlg, "dialog already showing");
-    allowDlg = false;
+    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, allowPersistentDlg, "dialog already showing");
+    allowPersistentDlg = false;
     NDB_DBUS_USB_ASSERT((void) 0);
     NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialogFactory_getConfirmationDialog && nSym.ConfirmationDialog__setTitle &&
         nSym.ConfirmationDialog__setText && nSym.ConfirmationDialog__showCloseButton && nSym.ConfirmationDialog__setRejectOnOutsideTap);
@@ -421,7 +425,7 @@ void NDB::dlgConfirmPersistentShow(QString const& title, QString const& body) {
     // This makes the dialog a true modal, where you cannot tap outside it to dismiss
     nSym.ConfirmationDialog__setRejectOnOutsideTap(persistentDlg, false);
     persistentDlg->setModal(true);
-    QObject::connect(persistentDlg, &QDialog::finished, this, &NDB::allowDialog);
+    QObject::connect(persistentDlg, &QDialog::finished, this, &NDB::allowPersistentDialog);
     QObject::connect(persistentDlg, &QDialog::finished, persistentDlg, &QDialog::deleteLater);
     persistentDlg->open();
 }
@@ -433,7 +437,7 @@ void NDB::dlgConfirmPersistentShow(QString const& title, QString const& body) {
  * replacing the existing body text.
  */ 
 void NDB::dlgConfirmPersistentChange(QString const& body) {
-    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowDlg, "dialog not showing");
+    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowPersistentDlg, "dialog not showing");
     NDB_DBUS_SYM_ASSERT((void) 0, nSym.ConfirmationDialog__setText);
     nSym.ConfirmationDialog__setText(persistentDlg, body);
 }
@@ -445,7 +449,7 @@ void NDB::dlgConfirmPersistentChange(QString const& body) {
  * error if the dialog has already been closed by the user.
  */
 void NDB::dlgConfirmPersistentClose() {
-    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowDlg, "dialog not showing");
+    NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowPersistentDlg, "dialog not showing");
     persistentDlg->accept();
 }
 

--- a/src/ndb/ndb.cc
+++ b/src/ndb/ndb.cc
@@ -435,6 +435,8 @@ void NDB::dlgConfirmPersistentShow(QString const& title, QString const& body) {
  * 
  * Set the body text of the currently displayed persistent dialog to \a body
  * replacing the existing body text.
+ * 
+ * There will be an error if the user has closed the dialog.
  */ 
 void NDB::dlgConfirmPersistentChange(QString const& body) {
     NDB_DBUS_ASSERT((void) 0, QDBusError::AccessDenied, !allowPersistentDlg, "dialog not showing");

--- a/src/ndb/ndb.h
+++ b/src/ndb/ndb.h
@@ -71,6 +71,7 @@ class NDB : public QObject, protected QDBusContext {
         void mwcHome();
         // Confirmation Dialogs
         void dlgConfirmPersistentShow(QString const& title, QString const& body);
+        void dlgConfirmPersistentChange(QString const& body);
         void dlgConfirmPersistentClose();
         void dlgConfirmNoBtn(QString const& title, QString const& body);
         void dlgConfirmAccept(QString const& title, QString const& body, QString const& acceptText);

--- a/src/ndb/ndb.h
+++ b/src/ndb/ndb.h
@@ -70,6 +70,8 @@ class NDB : public QObject, protected QDBusContext {
         void mwcToast(int toastDuration, QString const& msgMain, QString const& msgSub = QStringLiteral(""));
         void mwcHome();
         // Confirmation Dialogs
+        void dlgConfirmShowPersistent(QString const& title, QString const& body);
+        void dlgConfirmClosePersistent();
         void dlgConfirmNoBtn(QString const& title, QString const& body);
         void dlgConfirmAccept(QString const& title, QString const& body, QString const& acceptText);
         void dlgConfirmReject(QString const& title, QString const& body, QString const& rejectText);
@@ -113,6 +115,8 @@ class NDB : public QObject, protected QDBusContext {
             void (*ConfirmationDialog__setText)(ConfirmationDialog* _this, QString const&);
             void (*ConfirmationDialog__setAcceptButtonText)(ConfirmationDialog* _this, QString const&);
             void (*ConfirmationDialog__setRejectButtonText)(ConfirmationDialog* _this, QString const&);
+            void (*ConfirmationDialog__showCloseButton)(ConfirmationDialog* _this, bool show);
+            void (*ConfirmationDialog__setRejectOnOutsideTap)(ConfirmationDialog* _this, bool setReject);
             MainWindowController *(*MainWindowController_sharedInstance)();
             void (*MainWindowController_toast)(MainWindowController*, QString const&, QString const&, int);
             QWidget *(*MainWindowController_currentView)(MainWindowController*);
@@ -134,6 +138,7 @@ class NDB : public QObject, protected QDBusContext {
         void dlgConfirmation(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText);
         void pwrAction(const char *action);
         void rvConnectSignals(QWidget* rv);
+        ConfirmationDialog* persistentDlg;
 };
 
 #endif

--- a/src/ndb/ndb.h
+++ b/src/ndb/ndb.h
@@ -70,8 +70,8 @@ class NDB : public QObject, protected QDBusContext {
         void mwcToast(int toastDuration, QString const& msgMain, QString const& msgSub = QStringLiteral(""));
         void mwcHome();
         // Confirmation Dialogs
-        void dlgConfirmShowPersistent(QString const& title, QString const& body);
-        void dlgConfirmClosePersistent();
+        void dlgConfirmPersistentShow(QString const& title, QString const& body);
+        void dlgConfirmPersistentClose();
         void dlgConfirmNoBtn(QString const& title, QString const& body);
         void dlgConfirmAccept(QString const& title, QString const& body, QString const& acceptText);
         void dlgConfirmReject(QString const& title, QString const& body, QString const& rejectText);

--- a/src/ndb/ndb.h
+++ b/src/ndb/ndb.h
@@ -97,12 +97,14 @@ class NDB : public QObject, protected QDBusContext {
         void pwrReboot();
     protected Q_SLOTS:
         void allowDialog();
+        void allowPersistentDialog();
         void handleQSWCurrentChanged(int index);
         void handleQSWTimer();
         void handleStackedWidgetDestroyed();
     private:
         void *libnickel;
         bool allowDlg = true;
+        bool allowPersistentDlg = true;
         QSet<QString> connectedSignals;
         QStackedWidget *stackedWidget = nullptr;
         QString fwVersion;

--- a/src/ndb/ndb.h
+++ b/src/ndb/ndb.h
@@ -70,13 +70,13 @@ class NDB : public QObject, protected QDBusContext {
         void mwcToast(int toastDuration, QString const& msgMain, QString const& msgSub = QStringLiteral(""));
         void mwcHome();
         // Confirmation Dialogs
-        void dlgConfirmPersistentShow(QString const& title, QString const& body);
-        void dlgConfirmPersistentChange(QString const& body);
-        void dlgConfirmPersistentClose();
         void dlgConfirmNoBtn(QString const& title, QString const& body);
         void dlgConfirmAccept(QString const& title, QString const& body, QString const& acceptText);
         void dlgConfirmReject(QString const& title, QString const& body, QString const& rejectText);
         void dlgConfirmAcceptReject(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText);
+        void dlgConfirmModalMessage(QString const& title, QString const& body);
+        void dlgConfirmChangeBody(QString const& body);
+        void dlgConfirmClose();
         // PlugWorkFlowManager
         void pfmRescanBooks();
         void pfmRescanBooksFull();
@@ -97,14 +97,13 @@ class NDB : public QObject, protected QDBusContext {
         void pwrReboot();
     protected Q_SLOTS:
         void allowDialog();
-        void allowPersistentDialog();
         void handleQSWCurrentChanged(int index);
         void handleQSWTimer();
         void handleStackedWidgetDestroyed();
     private:
         void *libnickel;
         bool allowDlg = true;
-        bool allowPersistentDlg = true;
+        ConfirmationDialog* confirmDlg;
         QSet<QString> connectedSignals;
         QStackedWidget *stackedWidget = nullptr;
         QString fwVersion;
@@ -138,10 +137,9 @@ class NDB : public QObject, protected QDBusContext {
         QString getNickelMetaObjectDetails(const QMetaObject* nmo);
         template <typename T>
         void ndbConnectSignal(T *srcObj, const char *srcSignal, const char *dest);
-        void dlgConfirmation(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText);
+        void dlgConfirmation(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText, bool tapOutsideClose, bool sendSignal);
         void pwrAction(const char *action);
         void rvConnectSignals(QWidget* rv);
-        ConfirmationDialog* persistentDlg;
 };
 
 #endif


### PR DESCRIPTION
Carmelocotonto on MR asked in post [#22](https://www.mobileread.com/forums/showpost.php?p=4071419&postcount=22) the following:
> Could I even make the message stick while the file.sh is running? (not only 4 seconds)? [this is in regards to the toast]

I thought such a feature would be neat to have, so I've cobbled something together using the confirmation dialog stuff.

This PR introduces two new methods that allows you to show a 'persistent' dialog box, which will show until the other method is called to close it, or the user dismisses the dialog. This could be a way of blocking user interaction while doing an _Important Task(tm)_

It's possible to create a dialog that the user cannot close at all, but I thought it's probably safer to give the user an out for misbehaving scripts/programs.

This is marked WIP still, because I'm not entirely sold on the method naming, or if I've even taken the correct approach. Feedback is most welcome.