### PR TITLE
Add FSSync support

### DIFF
--- a/src/cli/ndb_cli.cc
+++ b/src/cli/ndb_cli.cc
@@ -170,6 +170,9 @@ void NDBCli::connectSignals() {
     NDBCLI_SIG_CONNECT(dlgConfirmTextInput, handleSignalParam1);
     NDBCLI_SIG_CONNECT(pfmAboutToConnect, handleSignalParam0);
     NDBCLI_SIG_CONNECT(pfmDoneProcessing, handleSignalParam0);
+    NDBCLI_SIG_CONNECT(fssFinished, handleSignalParam0);
+    NDBCLI_SIG_CONNECT(fssGotNumFilesToProcess, handleSignalParam1);
+    NDBCLI_SIG_CONNECT(fssParseProgress, handleSignalParam1);
     NDBCLI_SIG_CONNECT(wmLinkQualityForConnectedNetwork, handleSignalParam1);
     NDBCLI_SIG_CONNECT(wmMacAddressAvailable, handleSignalParam1);
     NDBCLI_SIG_CONNECT(wmNetworkConnected, handleSignalParam0);

--- a/src/ndb/NDBDbus.cc
+++ b/src/ndb/NDBDbus.cc
@@ -719,13 +719,13 @@ void NDBDbus::pfmRescanBooksFull() {
 /*!
  * \brief Begins a filesystem sync to add/remove content from onboard storage
  * 
- * This is a more targeted option to add new content compared to \a pfmRescanBooks 
- * and \a pfmRescanBooksFull. It is what the browser uses when downloading
+ * This is a more targeted option to add new content compared to \l pfmRescanBooks 
+ * and \l pfmRescanBooksFull. It is what the browser uses when downloading
  * ebook files.
  * 
- * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
- * to be added, \a fssParseProgress to specify the current progress, and the 
- * \a fssFinished signal is emitted when complete.
+ * Emits \l fssGotNumFilesToProcess signal to specify the number of files 
+ * to be added, \l fssParseProgress to specify the current progress, and the 
+ * \l fssFinished signal is emitted when complete.
  * 
  * \since 0.3.0
  */
@@ -737,13 +737,13 @@ void NDBDbus::n3fssSyncOnboard() {
 /*!
  * \brief Begins a filesystem sync to add/remove content from sd storage
  * 
- * This is a more targeted option to add new content compared to \a pfmRescanBooks 
- * and \a pfmRescanBooksFull. It is what the browser uses when downloading
+ * This is a more targeted option to add new content compared to \l pfmRescanBooks 
+ * and \l pfmRescanBooksFull. It is what the browser uses when downloading
  * ebook files.
  * 
- * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
- * to be added, \a fssParseProgress to specify the current progress, and the 
- * \a fssFinished signal is emitted when complete.
+ * Emits \l fssGotNumFilesToProcess signal to specify the number of files 
+ * to be added, \l fssParseProgress to specify the current progress, and the 
+ * \l fssFinished signal is emitted when complete.
  * 
  * \since 0.3.0
  */
@@ -755,13 +755,13 @@ void NDBDbus::n3fssSyncSD() {
 /*!
  * \brief Begins a filesystem sync to add/remove content from onboard and sd storage
  * 
- * This is a more targeted option to add new content compared to \a pfmRescanBooks 
- * and \a pfmRescanBooksFull. It is what the browser uses when downloading
+ * This is a more targeted option to add new content compared to \l pfmRescanBooks 
+ * and \l pfmRescanBooksFull. It is what the browser uses when downloading
  * ebook files.
  * 
- * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
- * to be added, \a fssParseProgress to specify the current progress, and the 
- * \a fssFinished signal is emitted when complete.
+ * Emits \l fssGotNumFilesToProcess signal to specify the number of files 
+ * to be added, \l fssParseProgress to specify the current progress, and the 
+ * \l fssFinished signal is emitted when complete.
  * 
  * \since 0.3.0
  */

--- a/src/ndb/NDBDbus.cc
+++ b/src/ndb/NDBDbus.cc
@@ -726,6 +726,8 @@ void NDBDbus::pfmRescanBooksFull() {
  * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
  * to be added, \a fssParseProgress to specify the current progress, and the 
  * \a fssFinished signal is emitted when complete.
+ * 
+ * \since 0.3.0
  */
 void NDBDbus::n3fssSyncOnboard() {
     QStringList path("/mnt/onboard");
@@ -742,6 +744,8 @@ void NDBDbus::n3fssSyncOnboard() {
  * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
  * to be added, \a fssParseProgress to specify the current progress, and the 
  * \a fssFinished signal is emitted when complete.
+ * 
+ * \since 0.3.0
  */
 void NDBDbus::n3fssSyncSD() {
     QStringList path("/mnt/sd");
@@ -758,6 +762,8 @@ void NDBDbus::n3fssSyncSD() {
  * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
  * to be added, \a fssParseProgress to specify the current progress, and the 
  * \a fssFinished signal is emitted when complete.
+ * 
+ * \since 0.3.0
  */
 void NDBDbus::n3fssSyncBoth() {
     QStringList paths = QStringList() << "/mnt/onboard" << "/mnt/sd";

--- a/src/ndb/NDBDbus.cc
+++ b/src/ndb/NDBDbus.cc
@@ -716,16 +716,49 @@ void NDBDbus::pfmRescanBooksFull() {
     return ndbNickelMisc("rescan_books_full");
 }
 
+/*!
+ * \brief Begins a filesystem sync to add/remove content from onboard storage
+ * 
+ * This is a more targeted option to add new content compared to \a pfmRescanBooks 
+ * and \a pfmRescanBooksFull. It is what the browser uses when downloading
+ * ebook files.
+ * 
+ * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
+ * to be added, \a fssParseProgress to specify the current progress, and the 
+ * \a fssFinished signal is emitted when complete.
+ */
 void NDBDbus::n3fssSyncOnboard() {
     QStringList path("/mnt/onboard");
     return n3fssSync(&path);
 }
 
+/*!
+ * \brief Begins a filesystem sync to add/remove content from sd storage
+ * 
+ * This is a more targeted option to add new content compared to \a pfmRescanBooks 
+ * and \a pfmRescanBooksFull. It is what the browser uses when downloading
+ * ebook files.
+ * 
+ * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
+ * to be added, \a fssParseProgress to specify the current progress, and the 
+ * \a fssFinished signal is emitted when complete.
+ */
 void NDBDbus::n3fssSyncSD() {
     QStringList path("/mnt/sd");
     return n3fssSync(&path);
 }
 
+/*!
+ * \brief Begins a filesystem sync to add/remove content from onboard and sd storage
+ * 
+ * This is a more targeted option to add new content compared to \a pfmRescanBooks 
+ * and \a pfmRescanBooksFull. It is what the browser uses when downloading
+ * ebook files.
+ * 
+ * Emits \a fssGotNumFilesToProcess signal to specify the number of files 
+ * to be added, \a fssParseProgress to specify the current progress, and the 
+ * \a fssFinished signal is emitted when complete.
+ */
 void NDBDbus::n3fssSyncBoth() {
     QStringList paths = QStringList() << "/mnt/onboard" << "/mnt/sd";
     return n3fssSync(&paths);

--- a/src/ndb/NDBDbus.h
+++ b/src/ndb/NDBDbus.h
@@ -19,6 +19,8 @@ typedef void MainWindowController;
 typedef QDialog ConfirmationDialog;
 typedef QWidget N3Dialog;
 typedef void Device;
+typedef QObject FSSyncManager;
+typedef FSSyncManager N3FSSyncManager;
 
 #ifndef NDB_DBUS_IFACE_NAME
     #define NDB_DBUS_IFACE_NAME "com.github.shermp.nickeldbus"
@@ -48,6 +50,10 @@ class NDBDbus : public QObject, protected QDBusContext {
         // PlugworkFlowManager signals
         void pfmDoneProcessing();
         void pfmAboutToConnect();
+        // FSSyncManager signals
+        void fssFinished();
+        void fssGotNumFilesToProcess(int num);
+        void fssParseProgress(int progress);
         // WirelessManager signals
         void wmTryingToConnect();
         void wmNetworkConnected();
@@ -94,6 +100,10 @@ class NDBDbus : public QObject, protected QDBusContext {
         // PlugWorkFlowManager
         void pfmRescanBooks();
         void pfmRescanBooksFull();
+        // N3FSSyncManager
+        void n3fssSyncOnboard();
+        void n3fssSyncSD();
+        void n3fssSyncBoth();
         // Wireless methods (WirelessFlowManager)
         void wfmConnectWireless();
         void wfmConnectWirelessSilently();
@@ -138,6 +148,8 @@ class NDBDbus : public QObject, protected QDBusContext {
             Device *(*Device__getCurrentDevice)();
             QByteArray (*Device__userAgent)(Device*);
             QSize (*Image__sizeForType)(Device*, QString const&);
+            N3FSSyncManager* (*N3FSSyncManager__sharedInstance)();
+            void (*N3FSSyncManager__sync)(N3FSSyncManager* _this, QStringList* paths);
         } nSym;
         QTimer *viewTimer;
         bool ndbInUSBMS();
@@ -152,6 +164,7 @@ class NDBDbus : public QObject, protected QDBusContext {
         void rvConnectSignals(QWidget* rv);
         void dlgConfirmLineEditFull(QString const& title, QString const& acceptText, QString const& rejectText, bool isPassword, QString const& setText);
         enum Result dlgConfirmCreatePreset(QString const& title, QString const& body, QString const& acceptText, QString const& rejectText);
+        void n3fssSync(QStringList* paths);
 };
 
 } // namespace NDB


### PR DESCRIPTION
Add support for adding content using `N3FSSyncManager` instead of the oversized hammer that is the PlugWorkflowManager methods.

This is how the web browser adds downloaded books to the database.

This should be safe, but @pgaskin if you have a minute to take a look, it would be much appreciated.